### PR TITLE
correct the esperanto layout to official standard

### DIFF
--- a/static/layouts/esperanto/qwerty.kb
+++ b/static/layouts/esperanto/qwerty.kb
@@ -1,3 +1,3 @@
-ĥ ŝ e r t  ŭ u i o p
-a s d f g  h j k l ĝ
-z ĉ c v b  n m ĵ , .
+ŝ ĝ e r t  ŭ u i o p
+a s d f g  h j k l ;
+z ĉ c v b  n m , . /


### PR DESCRIPTION
fixme: allow keys outside of central 3x10 area